### PR TITLE
feat: support token-only authentication without username

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -180,9 +180,15 @@ class Config {
       {
         type: 'input',
         name: 'username',
-        message: 'Username (email):',
-        default: this.get('username'),
-        validate: (input) => input ? true : 'Username is required'
+        message: 'Username (email, or type "none" to use token-only auth):',
+        default: this.get('username') || '',
+        // Allow empty username to support token-only authentication
+        validate: () => true,
+        // Transform "none" or empty string to empty
+        filter: (input) => {
+          const trimmed = input.trim().toLowerCase();
+          return (trimmed === 'none' || trimmed === '') ? '' : input.trim();
+        }
       },
       {
         type: 'password',
@@ -199,6 +205,10 @@ class Config {
       this.set('server', answers.server.replace(/\/$/, '')); // Remove trailing slash
       this.set('username', answers.username);
       this.set('token', answers.token);
+
+      if (!answers.username) {
+        console.log(chalk.yellow('\nNote: You left username blank. Token-only authentication will be used.'));
+      }
 
       console.log(chalk.green('\n✓ Configuration saved!'));
       


### PR DESCRIPTION
## Summary

This PR enables token-only authentication by making the username field optional during `jira init` setup.

## Changes

- **Updated username prompt** to accept empty value or 'none' keyword
- **Added input filter** to transform 'none' (case-insensitive) to empty string
- **Display informational message** when username is left blank
- **Leverages existing Bearer token support** in JiraClient

## Motivation

Some JIRA configurations and personal access token setups work better with token-only authentication. Previously, users were forced to enter a username/email even when not needed.

## How to Use

During `jira init` or `jira config`:
1. When prompted for username, either:
   - Press Enter to leave blank (if no default exists)
   - Type `none` (case-insensitive)
   - Delete existing default and press Enter

The CLI will display: _"Note: You left username blank. Token-only authentication will be used."_

## Testing

- ✅ All 82 existing tests pass
- ✅ ESLint validation passes
- ✅ Manual testing confirms token-only auth works
- ✅ Filter logic tested with various inputs

## Semantic Release Impact

This is a **minor feature** (`feat:`) commit, which will trigger a **minor version bump** (1.0.1 → 1.1.0) when merged to main.

## Related Issues

Resolves user request for optional username during setup.