### PR TITLE
feat(issue): add remote link support

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,43 @@ jira issue c add PROJ-123 "Quick comment"
 jira issue c list PROJ-123
 ```
 
+### Manage Remote Links
+
+Attach external resources (GitHub PRs, CI runs, dashboards, docs) to a Jira issue as Remote Links.
+
+```bash
+# List remote links on an issue
+jira issue remote-link list PROJ-123
+
+# List in JSON format
+jira issue remote-link list PROJ-123 --format json
+
+# Filter by globalId (useful to check if a link already exists)
+jira issue remote-link list PROJ-123 --global-id https://github.com/org/repo/pull/42
+
+# Add a remote link
+jira issue remote-link add PROJ-123 \
+    --url https://github.com/org/repo/pull/42 \
+    --title "org/repo#42"
+
+# Add with globalId for upsert behavior (Jira updates existing link with same globalId)
+jira issue remote-link add PROJ-123 \
+    --url https://github.com/org/repo/pull/42 \
+    --title "org/repo#42" \
+    --global-id https://github.com/org/repo/pull/42 \
+    --relationship "relates to"
+
+# Update an existing remote link
+jira issue remote-link update PROJ-123 12345 --title "Updated title"
+
+# Delete a remote link (requires --force)
+jira issue remote-link delete PROJ-123 12345 --force
+
+# Using command alias
+jira issue rl list PROJ-123
+jira issue rl add PROJ-123 --url https://example.com --title "Example"
+```
+
 ### Project Management
 
 ```bash
@@ -313,6 +350,10 @@ jira sprint list --board 123 --state active
 | `issue comment list <key>` | List comments on issue | `--format <table\|json>` (default: table) |
 | `issue comment edit <id> [text]` | Edit existing comment | `[text]` or `--file <path>` |
 | `issue comment delete <id>` | Delete comment | **Required:** `--force` |
+| `issue remote-link list <key>` | List remote links on issue (alias: rl) | `--format <table\|json>` (default: table), `--global-id <id>` |
+| `issue remote-link add <key>` | Add remote link to issue | **Required:** `--url <url>`, `--title <title>`<br>**Optional:** `--global-id <id>`, `--relationship <rel>`, `--summary <text>`, `--icon-url <url>`, `--icon-title <title>` |
+| `issue remote-link update <key> <linkId>` | Update an existing remote link | **At least one required:**<br>`--url <url>`, `--title <title>`, `--relationship <rel>`, `--summary <text>`, `--icon-url <url>`, `--icon-title <title>` |
+| `issue remote-link delete <key> <linkId>` | Delete remote link | **Required:** `--force` |
 | `project list` | List all projects | `--type <type>`, `--category <category>` |
 | `project view <key>` | View project details | - |
 | `project components <key>` | List project components | - |
@@ -381,6 +422,19 @@ jira issue comment edit 12345 "Updated comment"
 
 # Delete a comment
 jira issue comment delete 12345 --force
+
+# Add a GitHub PR as a remote link
+jira issue remote-link add PROJ-123 \
+    --url https://github.com/org/repo/pull/42 \
+    --title "org/repo#42" \
+    --global-id https://github.com/org/repo/pull/42 \
+    --relationship "relates to"
+
+# List remote links
+jira issue remote-link list PROJ-123
+
+# Delete a remote link
+jira issue remote-link delete PROJ-123 12345 --force
 
 # List all projects
 jira project list

--- a/bin/commands/issue.js
+++ b/bin/commands/issue.js
@@ -705,7 +705,7 @@ async function listRemoteLinks(client, io, issueKey, options = {}) {
     });
     spinner.stop();
 
-    if (!Array.isArray(links) || links.length === 0) {
+    if (links.length === 0) {
       io.info(`No remote links found for ${issueKey}`);
       return;
     }
@@ -762,6 +762,30 @@ async function addRemoteLink(client, io, issueKey, options = {}) {
   }
 }
 
+function mergeRemoteLinkPayload(existing, options) {
+  const base = { ...(existing || {}) };
+  delete base.id;
+  delete base.self;
+
+  const payload = {
+    ...base,
+    object: { ...(base.object || {}) }
+  };
+
+  if (options.url) payload.object.url = options.url;
+  if (options.title) payload.object.title = options.title;
+  if (options.summary) payload.object.summary = options.summary;
+  if (options.relationship) payload.relationship = options.relationship;
+
+  if (options.iconUrl || options.iconTitle) {
+    payload.object.icon = { ...(payload.object.icon || {}) };
+    if (options.iconUrl) payload.object.icon.url16x16 = options.iconUrl;
+    if (options.iconTitle) payload.object.icon.title = options.iconTitle;
+  }
+
+  return payload;
+}
+
 async function updateRemoteLink(client, io, issueKey, linkId, options = {}) {
   if (!options.url && !options.title && !options.summary &&
       !options.relationship && !options.iconUrl && !options.iconTitle) {
@@ -780,7 +804,11 @@ async function updateRemoteLink(client, io, issueKey, linkId, options = {}) {
     );
   }
 
-  const payload = buildRemoteLinkPayload(options);
+  const fetchSpinner = io.spinner(`Loading remote link ${linkId}...`);
+  const existing = await client.getRemoteLink(issueKey, linkId);
+  fetchSpinner.stop();
+
+  const payload = mergeRemoteLinkPayload(existing, options);
 
   const spinner = io.spinner(`Updating remote link ${linkId}...`);
   await client.updateRemoteLink(issueKey, linkId, payload);

--- a/bin/commands/issue.js
+++ b/bin/commands/issue.js
@@ -4,7 +4,8 @@ const {
   displayIssueDetails,
   formatIssueAsMarkdown,
   buildJQL,
-  createCommentsTable
+  createCommentsTable,
+  createRemoteLinksTable
 } = require('../../lib/utils');
 const chalk = require('chalk');
 const fs = require('fs');
@@ -216,11 +217,111 @@ function createIssueCommand(factory) {
     .action(async (commentId, options) => {
       const io = factory.getIOStreams();
       const client = await factory.getJiraClient();
-      
+
       try {
         await deleteComment(client, io, commentId, options);
       } catch (err) {
         io.error(`Failed to delete comment: ${err.message}`);
+        process.exit(1);
+      }
+    });
+
+  // Remote link subcommand
+  const remoteLinkCommand = command
+    .command('remote-link')
+    .description('Manage issue remote links')
+    .alias('rl');
+
+  remoteLinkCommand
+    .command('list <key>')
+    .description('list remote links on an issue\n\n' +
+      'Examples:\n' +
+      '  $ jira issue remote-link list PROJ-123\n' +
+      '  $ jira issue remote-link list PROJ-123 --format json\n' +
+      '  $ jira issue remote-link list PROJ-123 --global-id https://example.com/resource')
+    .option('--format <format>', 'output format (table, json)', 'table')
+    .option('--global-id <id>', 'filter by globalId')
+    .action(async (key, options) => {
+      const io = factory.getIOStreams();
+      const client = await factory.getJiraClient();
+
+      try {
+        await listRemoteLinks(client, io, key, options);
+      } catch (err) {
+        io.error(`Failed to list remote links: ${err.message}`);
+        process.exit(1);
+      }
+    });
+
+  remoteLinkCommand
+    .command('add <key>')
+    .description('add a remote link to an issue\n\n' +
+      'Examples:\n' +
+      '  $ jira issue remote-link add PROJ-123 \\\n' +
+      '      --url https://github.com/org/repo/pull/42 \\\n' +
+      '      --title "org/repo#42"\n' +
+      '  $ jira issue remote-link add PROJ-123 \\\n' +
+      '      --url https://github.com/org/repo/pull/42 \\\n' +
+      '      --title "org/repo#42" \\\n' +
+      '      --global-id https://github.com/org/repo/pull/42 \\\n' +
+      '      --relationship "relates to"')
+    .option('--url <url>', 'external resource URL (required)')
+    .option('--title <title>', 'link title (required)')
+    .option('--global-id <id>', 'stable identifier for upsert (recommended)')
+    .option('--relationship <relationship>', 'link relationship (e.g., "relates to")')
+    .option('--summary <summary>', 'optional summary shown under the title')
+    .option('--icon-url <url>', 'optional 16x16 icon URL')
+    .option('--icon-title <title>', 'optional icon alt text')
+    .action(async (key, options) => {
+      const io = factory.getIOStreams();
+      const client = await factory.getJiraClient();
+
+      try {
+        await addRemoteLink(client, io, key, options);
+      } catch (err) {
+        io.error(`Failed to add remote link: ${err.message}`);
+        process.exit(1);
+      }
+    });
+
+  remoteLinkCommand
+    .command('update <key> <linkId>')
+    .description('update an existing remote link\n\n' +
+      'Examples:\n' +
+      '  $ jira issue remote-link update PROJ-123 12345 --title "Updated title"\n' +
+      '  $ jira issue remote-link update PROJ-123 12345 --url https://example.com/new')
+    .option('--url <url>', 'new resource URL')
+    .option('--title <title>', 'new link title')
+    .option('--relationship <relationship>', 'new relationship')
+    .option('--summary <summary>', 'new summary')
+    .option('--icon-url <url>', 'new icon URL')
+    .option('--icon-title <title>', 'new icon alt text')
+    .action(async (key, linkId, options) => {
+      const io = factory.getIOStreams();
+      const client = await factory.getJiraClient();
+
+      try {
+        await updateRemoteLink(client, io, key, linkId, options);
+      } catch (err) {
+        io.error(`Failed to update remote link: ${err.message}`);
+        process.exit(1);
+      }
+    });
+
+  remoteLinkCommand
+    .command('delete <key> <linkId>')
+    .description('delete a remote link\n\n' +
+      'Examples:\n' +
+      '  $ jira issue remote-link delete PROJ-123 12345 --force')
+    .option('-f, --force', 'force delete without confirmation')
+    .action(async (key, linkId, options) => {
+      const io = factory.getIOStreams();
+      const client = await factory.getJiraClient();
+
+      try {
+        await deleteRemoteLink(client, io, key, linkId, options);
+      } catch (err) {
+        io.error(`Failed to delete remote link: ${err.message}`);
         process.exit(1);
       }
     });
@@ -574,6 +675,137 @@ async function deleteComment(client, io, commentId, options = {}) {
   spinner.stop();
 
   io.success(`Comment ${commentId} deleted successfully`);
+}
+
+function buildRemoteLinkPayload(options) {
+  const payload = { object: {} };
+
+  if (options.url) payload.object.url = options.url;
+  if (options.title) payload.object.title = options.title;
+  if (options.summary) payload.object.summary = options.summary;
+
+  if (options.iconUrl || options.iconTitle) {
+    payload.object.icon = {};
+    if (options.iconUrl) payload.object.icon.url16x16 = options.iconUrl;
+    if (options.iconTitle) payload.object.icon.title = options.iconTitle;
+  }
+
+  if (options.globalId) payload.globalId = options.globalId;
+  if (options.relationship) payload.relationship = options.relationship;
+
+  return payload;
+}
+
+async function listRemoteLinks(client, io, issueKey, options = {}) {
+  const spinner = io.spinner(`Fetching remote links for ${issueKey}...`);
+
+  try {
+    const links = await client.getRemoteLinks(issueKey, {
+      globalId: options.globalId
+    });
+    spinner.stop();
+
+    if (!Array.isArray(links) || links.length === 0) {
+      io.info(`No remote links found for ${issueKey}`);
+      return;
+    }
+
+    io.out(chalk.bold(`\nRemote links for ${issueKey} (${links.length} total):\n`));
+
+    if (options.format === 'json') {
+      io.out(JSON.stringify(links, null, 2));
+    } else {
+      const table = createRemoteLinksTable(links);
+      io.out(table.toString());
+    }
+
+  } catch (err) {
+    spinner.stop();
+    throw err;
+  }
+}
+
+async function addRemoteLink(client, io, issueKey, options = {}) {
+  if (!options.url || !options.title) {
+    throw new Error(
+      'Missing required options for adding a remote link.\n\n' +
+      'Usage: jira issue remote-link add <KEY> --url <URL> --title <TITLE> [options]\n\n' +
+      'Required options:\n' +
+      '  --url <URL>              External resource URL\n' +
+      '  --title <TITLE>          Link title\n\n' +
+      'Optional:\n' +
+      '  --global-id <ID>         Stable identifier for upsert behavior\n' +
+      '  --relationship <REL>     Link relationship (e.g., "relates to")\n' +
+      '  --summary <TEXT>         Summary shown under the title\n' +
+      '  --icon-url <URL>         16x16 icon URL\n' +
+      '  --icon-title <TITLE>     Icon alt text\n\n' +
+      'Example:\n' +
+      '  jira issue remote-link add PROJ-123 \\\n' +
+      '      --url https://github.com/org/repo/pull/42 \\\n' +
+      '      --title "org/repo#42" \\\n' +
+      '      --global-id https://github.com/org/repo/pull/42'
+    );
+  }
+
+  const payload = buildRemoteLinkPayload(options);
+
+  const spinner = io.spinner(`Adding remote link to ${issueKey}...`);
+  const result = await client.addRemoteLink(issueKey, payload);
+  spinner.stop();
+
+  io.success(`Remote link added to ${issueKey}`);
+  if (result && result.id) {
+    io.out(`Link ID: ${result.id}`);
+  }
+  if (result && result.self) {
+    io.out(`URL: ${result.self}`);
+  }
+}
+
+async function updateRemoteLink(client, io, issueKey, linkId, options = {}) {
+  if (!options.url && !options.title && !options.summary &&
+      !options.relationship && !options.iconUrl && !options.iconTitle) {
+    throw new Error(
+      'At least one field must be specified for update.\n\n' +
+      'Usage: jira issue remote-link update <KEY> <LINK-ID> [options]\n\n' +
+      'Available options:\n' +
+      '  --url <URL>              New resource URL\n' +
+      '  --title <TITLE>          New link title\n' +
+      '  --relationship <REL>     New relationship\n' +
+      '  --summary <TEXT>         New summary\n' +
+      '  --icon-url <URL>         New icon URL\n' +
+      '  --icon-title <TITLE>     New icon alt text\n\n' +
+      'Example:\n' +
+      '  jira issue remote-link update PROJ-123 12345 --title "Updated title"'
+    );
+  }
+
+  const payload = buildRemoteLinkPayload(options);
+
+  const spinner = io.spinner(`Updating remote link ${linkId}...`);
+  await client.updateRemoteLink(issueKey, linkId, payload);
+  spinner.stop();
+
+  io.success(`Remote link ${linkId} updated successfully`);
+}
+
+async function deleteRemoteLink(client, io, issueKey, linkId, options = {}) {
+  io.out(chalk.bold.red('\nWARNING: You are about to delete this remote link:'));
+  io.out(`  Issue: ${chalk.cyan(issueKey)}`);
+  io.out(`  Link ID: ${chalk.cyan(linkId)}\n`);
+
+  if (!options.force) {
+    throw new Error(
+      'Deletion requires --force flag to confirm.\n' +
+      `Use: jira issue remote-link delete ${issueKey} ${linkId} --force`
+    );
+  }
+
+  const spinner = io.spinner('Deleting remote link...');
+  await client.deleteRemoteLink(issueKey, linkId);
+  spinner.stop();
+
+  io.success(`Remote link ${linkId} deleted successfully`);
 }
 
 module.exports = createIssueCommand;

--- a/lib/jira-client.js
+++ b/lib/jira-client.js
@@ -205,6 +205,14 @@ class JiraClient {
     const params = {};
     if (options.globalId) params.globalId = options.globalId;
     const response = await this.requestApi('get', `/issue/${issueKey}/remotelink`, { params });
+    const data = response.data;
+    if (Array.isArray(data)) return data;
+    if (data && typeof data === 'object') return [data];
+    return [];
+  }
+
+  async getRemoteLink(issueKey, linkId) {
+    const response = await this.requestApi('get', `/issue/${issueKey}/remotelink/${linkId}`);
     return response.data;
   }
 

--- a/lib/jira-client.js
+++ b/lib/jira-client.js
@@ -200,6 +200,29 @@ class JiraClient {
     return true;
   }
 
+  // Remote links
+  async getRemoteLinks(issueKey, options = {}) {
+    const params = {};
+    if (options.globalId) params.globalId = options.globalId;
+    const response = await this.requestApi('get', `/issue/${issueKey}/remotelink`, { params });
+    return response.data;
+  }
+
+  async addRemoteLink(issueKey, linkData) {
+    const response = await this.requestApi('post', `/issue/${issueKey}/remotelink`, linkData);
+    return response.data;
+  }
+
+  async updateRemoteLink(issueKey, linkId, linkData) {
+    const response = await this.requestApi('put', `/issue/${issueKey}/remotelink/${linkId}`, linkData);
+    return response.data;
+  }
+
+  async deleteRemoteLink(issueKey, linkId) {
+    await this.requestApi('delete', `/issue/${issueKey}/remotelink/${linkId}`);
+    return true;
+  }
+
   normalizeApiVersionMode(apiVersion) {
     if (!apiVersion) return 'auto';
     if (apiVersion === 'auto') return 'auto';

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -319,6 +319,33 @@ function createCommentsTable(comments) {
   return table;
 }
 
+function createRemoteLinksTable(remoteLinks) {
+  const table = new Table({
+    head: [
+      chalk.bold('ID'),
+      chalk.bold('Title'),
+      chalk.bold('URL'),
+      chalk.bold('Relationship'),
+      chalk.bold('Global ID')
+    ],
+    colWidths: [10, 30, 45, 18, 30],
+    wordWrap: true
+  });
+
+  remoteLinks.forEach(link => {
+    const object = link.object || {};
+    table.push([
+      chalk.cyan(link.id),
+      object.title || '',
+      object.url || '',
+      link.relationship || '',
+      link.globalId || ''
+    ]);
+  });
+
+  return table;
+}
+
 // Display single comment details
 function displayCommentDetails(comment) {
   console.log(chalk.bold(`\nComment ID: ${comment.id}`));
@@ -350,6 +377,7 @@ module.exports = {
   warning,
   info,
   createCommentsTable,
+  createRemoteLinksTable,
   displayCommentDetails,
   convertAdfToText,
   resolveDescription

--- a/tests/commands/issue.test.js
+++ b/tests/commands/issue.test.js
@@ -40,6 +40,7 @@ describe('IssueCommand', () => {
       getTransitions: jest.fn(),
       transitionIssue: jest.fn(),
       getRemoteLinks: jest.fn(),
+      getRemoteLink: jest.fn(),
       addRemoteLink: jest.fn(),
       updateRemoteLink: jest.fn(),
       deleteRemoteLink: jest.fn()
@@ -273,6 +274,7 @@ describe('IssueCommand', () => {
     it('should require at least one field on update', async () => {
       await issueCommand.parseAsync(['node', 'jira', 'remote-link', 'update', 'PROJ-123', '10001']);
 
+      expect(mockJiraClient.getRemoteLink).not.toHaveBeenCalled();
       expect(mockJiraClient.updateRemoteLink).not.toHaveBeenCalled();
       expect(mockIOStreams.error).toHaveBeenCalledWith(
         expect.stringContaining('At least one field must be specified')
@@ -280,7 +282,20 @@ describe('IssueCommand', () => {
       expect(exitSpy).toHaveBeenCalledWith(1);
     });
 
-    it('should call updateRemoteLink with partial payload', async () => {
+    it('should fetch existing link and merge before PUT (preserves unchanged fields)', async () => {
+      mockJiraClient.getRemoteLink.mockResolvedValue({
+        id: 10001,
+        self: 'https://test.atlassian.net/rest/api/3/issue/PROJ-123/remotelink/10001',
+        globalId: 'https://example.com/resource',
+        application: { type: 'com.acme.tracker', name: 'Acme' },
+        relationship: 'relates to',
+        object: {
+          url: 'https://example.com/resource',
+          title: 'Old title',
+          summary: 'Unchanged summary',
+          icon: { url16x16: 'https://example.com/icon.png', title: 'icon' }
+        }
+      });
       mockJiraClient.updateRemoteLink.mockResolvedValue({});
 
       await issueCommand.parseAsync([
@@ -288,8 +303,45 @@ describe('IssueCommand', () => {
         '--title', 'Updated title'
       ]);
 
+      expect(mockJiraClient.getRemoteLink).toHaveBeenCalledWith('PROJ-123', '10001');
       expect(mockJiraClient.updateRemoteLink).toHaveBeenCalledWith('PROJ-123', '10001', {
-        object: { title: 'Updated title' }
+        globalId: 'https://example.com/resource',
+        application: { type: 'com.acme.tracker', name: 'Acme' },
+        relationship: 'relates to',
+        object: {
+          url: 'https://example.com/resource',
+          title: 'Updated title',
+          summary: 'Unchanged summary',
+          icon: { url16x16: 'https://example.com/icon.png', title: 'icon' }
+        }
+      });
+    });
+
+    it('should overlay multiple fields without dropping existing ones', async () => {
+      mockJiraClient.getRemoteLink.mockResolvedValue({
+        id: 10001,
+        self: 'https://...',
+        object: {
+          url: 'https://old.example.com',
+          title: 'Old title'
+        }
+      });
+      mockJiraClient.updateRemoteLink.mockResolvedValue({});
+
+      await issueCommand.parseAsync([
+        'node', 'jira', 'remote-link', 'update', 'PROJ-123', '10001',
+        '--url', 'https://new.example.com',
+        '--summary', 'New summary',
+        '--icon-url', 'https://example.com/new-icon.png'
+      ]);
+
+      expect(mockJiraClient.updateRemoteLink).toHaveBeenCalledWith('PROJ-123', '10001', {
+        object: {
+          url: 'https://new.example.com',
+          title: 'Old title',
+          summary: 'New summary',
+          icon: { url16x16: 'https://example.com/new-icon.png' }
+        }
       });
     });
 

--- a/tests/commands/issue.test.js
+++ b/tests/commands/issue.test.js
@@ -8,16 +8,23 @@ describe('IssueCommand', () => {
   let issueCommand;
 
   beforeEach(() => {
+    const outFn = jest.fn();
+    outFn.write = jest.fn();
     mockIOStreams = {
-      out: {
-        write: jest.fn()
-      },
+      out: outFn,
       println: jest.fn(),
       printError: jest.fn(),
       printSuccess: jest.fn(),
       success: jest.fn(),
       error: jest.fn(),
-      colorize: jest.fn()
+      info: jest.fn(),
+      colorize: jest.fn(),
+      spinner: jest.fn(() => ({
+        start: jest.fn(),
+        stop: jest.fn(),
+        succeed: jest.fn(),
+        fail: jest.fn()
+      }))
     };
 
     mockJiraClient = {
@@ -31,7 +38,11 @@ describe('IssueCommand', () => {
       updateComment: jest.fn(),
       deleteComment: jest.fn(),
       getTransitions: jest.fn(),
-      transitionIssue: jest.fn()
+      transitionIssue: jest.fn(),
+      getRemoteLinks: jest.fn(),
+      addRemoteLink: jest.fn(),
+      updateRemoteLink: jest.fn(),
+      deleteRemoteLink: jest.fn()
     };
 
     mockAnalytics = {
@@ -109,6 +120,197 @@ describe('IssueCommand', () => {
       const deleteCommand = commentCommand.commands.find(cmd => cmd.name() === 'delete');
       expect(deleteCommand).toBeDefined();
       expect(deleteCommand.description()).toContain('delete a comment');
+    });
+  });
+
+  describe('remote-link subcommand', () => {
+    let remoteLinkCommand;
+
+    beforeEach(() => {
+      remoteLinkCommand = issueCommand.commands.find(cmd => cmd.name() === 'remote-link');
+    });
+
+    it('should exist with correct alias', () => {
+      expect(remoteLinkCommand).toBeDefined();
+      expect(remoteLinkCommand.aliases()).toContain('rl');
+    });
+
+    it('should have list subcommand', () => {
+      const listCommand = remoteLinkCommand.commands.find(cmd => cmd.name() === 'list');
+      expect(listCommand).toBeDefined();
+      expect(listCommand.description()).toContain('list remote links');
+
+      const formatOption = listCommand.options.find(opt => opt.long === '--format');
+      expect(formatOption).toBeDefined();
+      expect(formatOption.defaultValue).toBe('table');
+
+      const globalIdOption = listCommand.options.find(opt => opt.long === '--global-id');
+      expect(globalIdOption).toBeDefined();
+    });
+
+    it('should have add subcommand with url and title options', () => {
+      const addCommand = remoteLinkCommand.commands.find(cmd => cmd.name() === 'add');
+      expect(addCommand).toBeDefined();
+      expect(addCommand.description()).toContain('add a remote link');
+
+      const urlOption = addCommand.options.find(opt => opt.long === '--url');
+      expect(urlOption).toBeDefined();
+
+      const titleOption = addCommand.options.find(opt => opt.long === '--title');
+      expect(titleOption).toBeDefined();
+
+      const globalIdOption = addCommand.options.find(opt => opt.long === '--global-id');
+      expect(globalIdOption).toBeDefined();
+
+      const relationshipOption = addCommand.options.find(opt => opt.long === '--relationship');
+      expect(relationshipOption).toBeDefined();
+    });
+
+    it('should have update subcommand', () => {
+      const updateCommand = remoteLinkCommand.commands.find(cmd => cmd.name() === 'update');
+      expect(updateCommand).toBeDefined();
+      expect(updateCommand.description()).toContain('update an existing remote link');
+    });
+
+    it('should have delete subcommand with force option', () => {
+      const deleteCommand = remoteLinkCommand.commands.find(cmd => cmd.name() === 'delete');
+      expect(deleteCommand).toBeDefined();
+      expect(deleteCommand.description()).toContain('delete a remote link');
+
+      const forceOption = deleteCommand.options.find(opt => opt.long === '--force');
+      expect(forceOption).toBeDefined();
+    });
+  });
+
+  describe('remote-link command execution', () => {
+    let exitSpy;
+
+    beforeEach(() => {
+      exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      exitSpy.mockRestore();
+    });
+
+    it('should call getRemoteLinks on list', async () => {
+      mockJiraClient.getRemoteLinks.mockResolvedValue([]);
+
+      await issueCommand.parseAsync(['node', 'jira', 'remote-link', 'list', 'PROJ-123']);
+
+      expect(mockJiraClient.getRemoteLinks).toHaveBeenCalledWith('PROJ-123', { globalId: undefined });
+    });
+
+    it('should pass globalId filter to getRemoteLinks', async () => {
+      mockJiraClient.getRemoteLinks.mockResolvedValue([]);
+
+      await issueCommand.parseAsync([
+        'node', 'jira', 'remote-link', 'list', 'PROJ-123',
+        '--global-id', 'https://example.com/resource'
+      ]);
+
+      expect(mockJiraClient.getRemoteLinks).toHaveBeenCalledWith('PROJ-123', {
+        globalId: 'https://example.com/resource'
+      });
+    });
+
+    it('should require --url and --title for add', async () => {
+      await issueCommand.parseAsync(['node', 'jira', 'remote-link', 'add', 'PROJ-123']);
+
+      expect(mockJiraClient.addRemoteLink).not.toHaveBeenCalled();
+      expect(mockIOStreams.error).toHaveBeenCalledWith(
+        expect.stringContaining('Missing required options')
+      );
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it('should build correct payload for add with required options', async () => {
+      mockJiraClient.addRemoteLink.mockResolvedValue({ id: 10001 });
+
+      await issueCommand.parseAsync([
+        'node', 'jira', 'remote-link', 'add', 'PROJ-123',
+        '--url', 'https://github.com/org/repo/pull/42',
+        '--title', 'org/repo#42'
+      ]);
+
+      expect(mockJiraClient.addRemoteLink).toHaveBeenCalledWith('PROJ-123', {
+        object: {
+          url: 'https://github.com/org/repo/pull/42',
+          title: 'org/repo#42'
+        }
+      });
+    });
+
+    it('should include globalId, relationship, summary, and icon in add payload', async () => {
+      mockJiraClient.addRemoteLink.mockResolvedValue({ id: 10001 });
+
+      await issueCommand.parseAsync([
+        'node', 'jira', 'remote-link', 'add', 'PROJ-123',
+        '--url', 'https://example.com/resource',
+        '--title', 'Example resource',
+        '--global-id', 'https://example.com/resource',
+        '--relationship', 'relates to',
+        '--summary', 'A resource summary',
+        '--icon-url', 'https://example.com/icon.png',
+        '--icon-title', 'Example icon'
+      ]);
+
+      expect(mockJiraClient.addRemoteLink).toHaveBeenCalledWith('PROJ-123', {
+        globalId: 'https://example.com/resource',
+        relationship: 'relates to',
+        object: {
+          url: 'https://example.com/resource',
+          title: 'Example resource',
+          summary: 'A resource summary',
+          icon: {
+            url16x16: 'https://example.com/icon.png',
+            title: 'Example icon'
+          }
+        }
+      });
+    });
+
+    it('should require at least one field on update', async () => {
+      await issueCommand.parseAsync(['node', 'jira', 'remote-link', 'update', 'PROJ-123', '10001']);
+
+      expect(mockJiraClient.updateRemoteLink).not.toHaveBeenCalled();
+      expect(mockIOStreams.error).toHaveBeenCalledWith(
+        expect.stringContaining('At least one field must be specified')
+      );
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it('should call updateRemoteLink with partial payload', async () => {
+      mockJiraClient.updateRemoteLink.mockResolvedValue({});
+
+      await issueCommand.parseAsync([
+        'node', 'jira', 'remote-link', 'update', 'PROJ-123', '10001',
+        '--title', 'Updated title'
+      ]);
+
+      expect(mockJiraClient.updateRemoteLink).toHaveBeenCalledWith('PROJ-123', '10001', {
+        object: { title: 'Updated title' }
+      });
+    });
+
+    it('should require --force on delete', async () => {
+      await issueCommand.parseAsync(['node', 'jira', 'remote-link', 'delete', 'PROJ-123', '10001']);
+
+      expect(mockJiraClient.deleteRemoteLink).not.toHaveBeenCalled();
+      expect(mockIOStreams.error).toHaveBeenCalledWith(
+        expect.stringContaining('--force flag to confirm')
+      );
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it('should call deleteRemoteLink when --force is provided', async () => {
+      mockJiraClient.deleteRemoteLink.mockResolvedValue(true);
+
+      await issueCommand.parseAsync([
+        'node', 'jira', 'remote-link', 'delete', 'PROJ-123', '10001', '--force'
+      ]);
+
+      expect(mockJiraClient.deleteRemoteLink).toHaveBeenCalledWith('PROJ-123', '10001');
     });
   });
 

--- a/tests/jira-client.test.js
+++ b/tests/jira-client.test.js
@@ -234,6 +234,40 @@ describe('JiraClient', () => {
       });
     });
 
+    test('getRemoteLinks should wrap single-object responses in an array', async () => {
+      const singleLink = { id: 10000, object: { url: 'https://example.com' } };
+      client.clientV3.request.mockResolvedValue({ data: singleLink });
+
+      const result = await client.getRemoteLinks('TEST-1', { globalId: 'https://example.com' });
+
+      expect(result).toEqual([singleLink]);
+    });
+
+    test('getRemoteLinks should return empty array for null/undefined data', async () => {
+      client.clientV3.request.mockResolvedValue({ data: null });
+
+      const result = await client.getRemoteLinks('TEST-1');
+
+      expect(result).toEqual([]);
+    });
+
+    test('getRemoteLink should make correct API call', async () => {
+      const mockLink = {
+        id: 10001,
+        globalId: 'https://example.com/resource',
+        object: { url: 'https://example.com/resource', title: 'Example' }
+      };
+      client.clientV3.request.mockResolvedValue({ data: mockLink });
+
+      const result = await client.getRemoteLink('TEST-1', '10001');
+
+      expect(client.clientV3.request).toHaveBeenCalledWith({
+        method: 'get',
+        url: '/issue/TEST-1/remotelink/10001'
+      });
+      expect(result).toEqual(mockLink);
+    });
+
     test('addRemoteLink should make correct API call', async () => {
       const payload = {
         globalId: 'https://example.com/resource',

--- a/tests/jira-client.test.js
+++ b/tests/jira-client.test.js
@@ -206,6 +206,77 @@ describe('JiraClient', () => {
       expect(client.clientV3.request).toHaveBeenCalledWith({ method: 'delete', url: '/comment/10000' });
       expect(result).toBe(true);
     });
+
+    test('getRemoteLinks should make correct API call', async () => {
+      const mockLinks = [{ id: 10000, object: { url: 'https://example.com', title: 'Example' } }];
+      client.clientV3.request.mockResolvedValue({ data: mockLinks });
+
+      const result = await client.getRemoteLinks('TEST-1');
+
+      expect(client.clientV3.request).toHaveBeenCalledWith({
+        method: 'get',
+        url: '/issue/TEST-1/remotelink',
+        params: {}
+      });
+      expect(result).toEqual(mockLinks);
+    });
+
+    test('getRemoteLinks should pass globalId filter when provided', async () => {
+      const mockLinks = [{ id: 10000 }];
+      client.clientV3.request.mockResolvedValue({ data: mockLinks });
+
+      await client.getRemoteLinks('TEST-1', { globalId: 'https://example.com/resource' });
+
+      expect(client.clientV3.request).toHaveBeenCalledWith({
+        method: 'get',
+        url: '/issue/TEST-1/remotelink',
+        params: { globalId: 'https://example.com/resource' }
+      });
+    });
+
+    test('addRemoteLink should make correct API call', async () => {
+      const payload = {
+        globalId: 'https://example.com/resource',
+        relationship: 'relates to',
+        object: { url: 'https://example.com/resource', title: 'Example' }
+      };
+      const mockResponse = { id: 10001, self: 'https://test.atlassian.net/rest/api/3/issue/TEST-1/remotelink/10001' };
+      client.clientV3.request.mockResolvedValue({ data: mockResponse });
+
+      const result = await client.addRemoteLink('TEST-1', payload);
+
+      expect(client.clientV3.request).toHaveBeenCalledWith({
+        method: 'post',
+        url: '/issue/TEST-1/remotelink',
+        data: payload
+      });
+      expect(result).toEqual(mockResponse);
+    });
+
+    test('updateRemoteLink should make correct API call', async () => {
+      const payload = { object: { url: 'https://example.com/new', title: 'Updated' } };
+      client.clientV3.request.mockResolvedValue({ data: {} });
+
+      await client.updateRemoteLink('TEST-1', '10001', payload);
+
+      expect(client.clientV3.request).toHaveBeenCalledWith({
+        method: 'put',
+        url: '/issue/TEST-1/remotelink/10001',
+        data: payload
+      });
+    });
+
+    test('deleteRemoteLink should make correct API call', async () => {
+      client.clientV3.request.mockResolvedValue({});
+
+      const result = await client.deleteRemoteLink('TEST-1', '10001');
+
+      expect(client.clientV3.request).toHaveBeenCalledWith({
+        method: 'delete',
+        url: '/issue/TEST-1/remotelink/10001'
+      });
+      expect(result).toBe(true);
+    });
   });
 
   // Error handling tests


### PR DESCRIPTION
## 📋 Summary

Adds first-class support for Jira issue **Remote Links** via the `/issue/{key}/remotelink` REST API, so automation can stay inside `jira-cli` instead of dropping down to raw `curl` or Python scripts.

Closes #23.

## 🎯 Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 📚 Documentation update
- [x] 🧪 Test improvements

## 🔍 Changes Made

- **`lib/jira-client.js`** — add `getRemoteLinks`, `addRemoteLink`, `updateRemoteLink`, `deleteRemoteLink`. Reuses the existing `requestApi` flow so v2/v3 auto-fallback applies for free.
- **`bin/commands/issue.js`** — new `remote-link` subcommand group (alias `rl`) with `list` / `add` / `update` / `delete`.
- **`lib/utils.js`** — `createRemoteLinksTable` for table output.
- **README.md** — usage examples and command reference.
- **Tests** — 5 client-level tests and 11 command-level tests (structure + execution paths).

### Commands

```bash
jira issue remote-link list PROJ-123
jira issue remote-link list PROJ-123 --format json
jira issue remote-link list PROJ-123 --global-id https://example.com/resource

jira issue remote-link add PROJ-123 \
    --url https://github.com/org/repo/pull/42 \
    --title "org/repo#42" \
    --global-id https://github.com/org/repo/pull/42 \
    --relationship "relates to"

jira issue remote-link update PROJ-123 12345 --title "Updated title"

jira issue remote-link delete PROJ-123 12345 --force
```

### Design Decisions

- **`--global-id` exposed as a flag**: Jira's native upsert-by-globalId means scripts can attach a PR/resource idempotently without a separate "does this link already exist?" check. This directly addresses the duplicate-avoidance concern the issue author raised in their follow-up comment.
- **`delete` requires both the issue key and link ID**: matches the REST endpoint shape and removes ambiguity about which issue the link belongs to. Also gated behind `--force`, consistent with `issue delete` and `issue comment delete`.
- **`update` added** (not in the original proposal): without it, changing a link's title or URL would require delete + recreate, which is awkward in scripts.
- **Non-interactive**: all inputs via flags, no prompts, consistent with the project's automation-first CLI philosophy.

## 🧪 Testing

- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Manual testing completed (verified `--help` output for the subcommand group and each subcommand)
- [x] Code coverage maintained/improved

## 📊 Test Results

```bash
$ npm test
Test Suites: 7 passed, 7 total
Tests:       135 passed, 135 total
```

16 new tests:
- `tests/jira-client.test.js`: `getRemoteLinks` (with/without globalId filter), `addRemoteLink`, `updateRemoteLink`, `deleteRemoteLink`
- `tests/commands/issue.test.js`: subcommand structure + execution paths including required-flag validation, payload construction (minimal, full, partial update), and `--force` gating on delete

## 🚀 Deployment Notes

- [x] No special deployment steps required

No config, env var, or dependency changes. Purely additive new subcommand group.

## 📝 Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## 🔗 Related Issues

- Closes #23

## 💬 Additional Notes

Follows the existing `comment` subcommand as a structural template (same pattern for `list`/`add`/`edit`/`delete` + alias + `--force` gating), so the mental model for existing users carries over directly.