### PR TITLE
fix(security): escape JQL string values to prevent injection

### DIFF
--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -1,6 +1,7 @@
 const config = require('./config');
 const chalk = require('chalk');
 const Table = require('cli-table3');
+const { escapeJqlString } = require('./utils');
 
 class Analytics {
   constructor() {
@@ -15,7 +16,7 @@ class Analytics {
   async getProjectStats(projectKey) {
     if (!this.client) await this.init();
 
-    const jql = `project = "${projectKey}"`;
+    const jql = `project = "${escapeJqlString(projectKey)}"`;
     const issues = await this.client.searchIssues(jql, {
       maxResults: 1000,
       fields: ['status', 'issuetype', 'assignee', 'created', 'resolved', 'priority']
@@ -77,7 +78,7 @@ class Analytics {
   async getUserWorkload(username) {
     if (!this.client) await this.init();
 
-    const jql = `assignee = "${username}" AND resolution = Unresolved`;
+    const jql = `assignee = "${escapeJqlString(username)}" AND resolution = Unresolved`;
     const issues = await this.client.searchIssues(jql, {
       maxResults: 1000,
       fields: ['status', 'issuetype', 'priority', 'project', 'created']

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -246,23 +246,36 @@ function displayIssueDetails(issue) {
   console.log(`\n${chalk.bold('URL:')} ${issue.self.replace(new RegExp(`/rest/api/(2|3)/issue/${issue.id}`), '/browse/' + issue.key)}`);
 }
 
+// Escape a value for safe use inside a JQL double-quoted string literal.
+// JQL treats backslash as the escape char; double quotes terminate the literal.
+// Newline/carriage return/tab can also terminate or corrupt parsing, so we
+// normalize them to their escaped forms.
+function escapeJqlString(value) {
+  return String(value)
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/\t/g, '\\t');
+}
+
 // Build JQL query from options
 function buildJQL(options) {
   const conditions = [];
 
   if (options.project) {
-    conditions.push(`project = "${options.project}"`);
+    conditions.push(`project = "${escapeJqlString(options.project)}"`);
   }
 
   if (options.assignee) {
     const assigneeValue = options.assignee === 'currentUser'
       ? 'currentUser()'
-      : `"${options.assignee}"`;
+      : `"${escapeJqlString(options.assignee)}"`;
     conditions.push(`assignee = ${assigneeValue}`);
   }
 
   if (options.status) {
-    conditions.push(`status = "${options.status}"`);
+    conditions.push(`status = "${escapeJqlString(options.status)}"`);
   }
 
   return conditions.length > 0 ? conditions.join(' AND ') : 'ORDER BY updated DESC';
@@ -372,6 +385,7 @@ module.exports = {
   displayIssueDetails,
   formatIssueAsMarkdown,
   buildJQL,
+  escapeJqlString,
   success,
   error,
   warning,

--- a/tests/analytics.test.js
+++ b/tests/analytics.test.js
@@ -1,0 +1,70 @@
+const Analytics = require('../lib/analytics');
+
+describe('Analytics', () => {
+  let analytics;
+  let searchIssuesMock;
+
+  beforeEach(() => {
+    analytics = new Analytics();
+    searchIssuesMock = jest.fn().mockResolvedValue({ total: 0, issues: [] });
+    analytics.client = { searchIssues: searchIssuesMock };
+  });
+
+  describe('getProjectStats JQL injection', () => {
+    it('should escape double quotes in projectKey', async () => {
+      await analytics.getProjectStats('TEST" OR project = "X');
+
+      expect(searchIssuesMock).toHaveBeenCalledWith(
+        'project = "TEST\\" OR project = \\"X"',
+        expect.any(Object)
+      );
+    });
+
+    it('should escape backslashes in projectKey', async () => {
+      await analytics.getProjectStats('A\\B');
+
+      expect(searchIssuesMock).toHaveBeenCalledWith(
+        'project = "A\\\\B"',
+        expect.any(Object)
+      );
+    });
+
+    it('should pass through legitimate project keys unchanged', async () => {
+      await analytics.getProjectStats('TEST');
+
+      expect(searchIssuesMock).toHaveBeenCalledWith(
+        'project = "TEST"',
+        expect.any(Object)
+      );
+    });
+  });
+
+  describe('getUserWorkload JQL injection', () => {
+    it('should escape double quotes in username', async () => {
+      await analytics.getUserWorkload('bob" OR assignee = "alice');
+
+      expect(searchIssuesMock).toHaveBeenCalledWith(
+        'assignee = "bob\\" OR assignee = \\"alice" AND resolution = Unresolved',
+        expect.any(Object)
+      );
+    });
+
+    it('should escape control characters in username', async () => {
+      await analytics.getUserWorkload('a\nb');
+
+      expect(searchIssuesMock).toHaveBeenCalledWith(
+        'assignee = "a\\nb" AND resolution = Unresolved',
+        expect.any(Object)
+      );
+    });
+
+    it('should pass through legitimate usernames unchanged', async () => {
+      await analytics.getUserWorkload('john.doe');
+
+      expect(searchIssuesMock).toHaveBeenCalledWith(
+        'assignee = "john.doe" AND resolution = Unresolved',
+        expect.any(Object)
+      );
+    });
+  });
+});

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -334,5 +334,70 @@ describe('Utils', () => {
 
       expect(jql).toBe('ORDER BY updated DESC');
     });
+
+    it('should escape double quotes in project to prevent JQL injection', () => {
+      const options = { project: 'TEST" OR project = "X' };
+      const jql = Utils.buildJQL(options);
+
+      expect(jql).toBe('project = "TEST\\" OR project = \\"X"');
+    });
+
+    it('should escape backslashes in values', () => {
+      const options = { project: 'A\\B' };
+      const jql = Utils.buildJQL(options);
+
+      expect(jql).toBe('project = "A\\\\B"');
+    });
+
+    it('should escape injection attempts in assignee', () => {
+      const options = { assignee: 'bob" OR assignee = "alice' };
+      const jql = Utils.buildJQL(options);
+
+      expect(jql).toBe('assignee = "bob\\" OR assignee = \\"alice"');
+    });
+
+    it('should escape injection attempts in status', () => {
+      const options = { status: 'Open" OR status = "Done' };
+      const jql = Utils.buildJQL(options);
+
+      expect(jql).toBe('status = "Open\\" OR status = \\"Done"');
+    });
+
+    it('should escape newlines and tabs in values', () => {
+      const options = { project: 'A\nB\tC\rD' };
+      const jql = Utils.buildJQL(options);
+
+      expect(jql).toBe('project = "A\\nB\\tC\\rD"');
+    });
+
+    it('should still treat currentUser sentinel as function call', () => {
+      const options = { assignee: 'currentUser' };
+      const jql = Utils.buildJQL(options);
+
+      expect(jql).toBe('assignee = currentUser()');
+    });
+  });
+
+  describe('escapeJqlString', () => {
+    it('should escape double quotes', () => {
+      expect(Utils.escapeJqlString('a"b')).toBe('a\\"b');
+    });
+
+    it('should escape backslashes before quotes', () => {
+      expect(Utils.escapeJqlString('a\\"b')).toBe('a\\\\\\"b');
+    });
+
+    it('should escape control characters', () => {
+      expect(Utils.escapeJqlString('a\nb\rc\td')).toBe('a\\nb\\rc\\td');
+    });
+
+    it('should coerce non-string inputs', () => {
+      expect(Utils.escapeJqlString(123)).toBe('123');
+      expect(Utils.escapeJqlString(null)).toBe('null');
+    });
+
+    it('should leave safe strings unchanged', () => {
+      expect(Utils.escapeJqlString('TEST-123')).toBe('TEST-123');
+    });
   });
 });


### PR DESCRIPTION
## 📋 Summary

Escape user-supplied values (`--project`, `--assignee`, `--status`) before interpolating them into JQL queries. Previously a crafted input could break out of the quoted literal and modify the query.

## 🎯 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## 🔍 Changes Made

- Added `escapeJqlString()` helper in `lib/utils.js` that escapes backslashes, double quotes, and control characters (`\n`, `\r`, `\t`)
- `buildJQL()` now routes `project`, `assignee`, and `status` values through the helper
- `currentUser` sentinel still resolves to the unquoted `currentUser()` function call
- Added 6 injection-attempt tests for `buildJQL` and 5 unit tests for `escapeJqlString`

## 🧪 Testing

- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Code coverage maintained/improved

## 📊 Test Results

```bash
Test Suites: 7 passed, 7 total
Tests:       150 passed, 150 total
```

Before: `--project 'TEST" OR project = "X'` → `project = "TEST" OR project = "X"` (query altered)
After:  `--project 'TEST" OR project = "X'` → `project = "TEST\" OR project = \"X"` (treated as a single literal project key)

## 🚀 Deployment Notes

- [x] No special deployment steps required

No behavior change for legitimate inputs (`TEST-123`, `currentUser`, `In Progress`).