### PR TITLE
chore(ci): bump release to Node 20 and actions to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
         node-version: [16.x, 18.x, 20.x]
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
@@ -51,10 +51,10 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     
     - name: Use Node.js 18.x
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: 18.x
         cache: 'npm'
@@ -70,12 +70,12 @@ jobs:
     if: github.event_name == 'pull_request'
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
     
     - name: Use Node.js 18.x
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: 18.x
         cache: 'npm'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,15 +18,15 @@ jobs:
     
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
         persist-credentials: false
-    
-    - name: Use Node.js 18.x
-      uses: actions/setup-node@v4
+
+    - name: Use Node.js 20.x
+      uses: actions/setup-node@v5
       with:
-        node-version: 18.x
+        node-version: 20.x
         cache: 'npm'
     
     - name: Install dependencies


### PR DESCRIPTION
## Why

The release run log was noisy with warnings (release succeeded, none were blocking):

1. **`npm warn EBADENGINE` (many)** — the release job ran on **Node 18.x** (EOL since 2025-04), but the `overrides`-pinned `npm@11.6.2` and its `@npmcli/*`/`@isaacs/*` sub-deps require Node `^20.17 || >=22.9`.
2. **`Node.js 20 is deprecated ... forced to run on Node.js 24`** — `actions/checkout@v4` and `actions/setup-node@v4` target the Node 20 action runtime, which GitHub is deprecating.

## Changes

- **release.yml**: Node `18.x` → `20.x` (resolves #1; matches the pinned npm), and `actions/checkout`/`actions/setup-node` `@v4` → `@v5` (resolves #2).
- **ci.yml**: `actions/checkout`/`actions/setup-node` `@v4` → `@v5` to clear the same runner deprecation repo-wide.

## Out of scope (intentionally unchanged)

- CI **test matrix** (`16.x / 18.x / 20.x`) and the **audit/commitlint** Node version — these validate consumer Node compatibility (`engines: >=14`), so they stay.
- `codecov/codecov-action@v3` — separate deprecation, left for its own change.
- The `marked()` deprecation in the release log comes from inside `@semantic-release`'s GitHub plugin and is not actionable here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)