### PR TITLE
ci: make CI EBADENGINE-free (Node 20-only jobs, codecov v5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [20.x]
     
     steps:
     - uses: actions/checkout@v5
@@ -53,7 +53,7 @@ jobs:
     
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v5
-      if: matrix.node-version == '18.x'
+      if: matrix.node-version == '20.x'
       continue-on-error: true
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x]
     
     steps:
     - uses: actions/checkout@v5
@@ -52,12 +52,12 @@ jobs:
       run: npm run test:coverage
     
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v5
       if: matrix.node-version == '18.x'
       continue-on-error: true
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./coverage/lcov.info
+        files: ./coverage/lcov.info
         flags: unittests
         name: codecov-umbrella
         fail_ci_if_error: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,10 +68,10 @@ jobs:
     steps:
     - uses: actions/checkout@v5
     
-    - name: Use Node.js 18.x
+    - name: Use Node.js 20.x
       uses: actions/setup-node@v5
       with:
-        node-version: 18.x
+        node-version: 20.x
         cache: 'npm'
     
     - name: Install dependencies
@@ -89,10 +89,10 @@ jobs:
       with:
         fetch-depth: 0
     
-    - name: Use Node.js 18.x
+    - name: Use Node.js 20.x
       uses: actions/setup-node@v5
       with:
-        node-version: 18.x
+        node-version: 20.x
         cache: 'npm'
     
     - name: Install dependencies


### PR DESCRIPTION
Drives the CI logs down to zero install/engine warnings. CI was already green; this is warning cleanup.

## Root cause

The `overrides`-pinned `npm@11.6.2` (and its `@npmcli/*`/`@isaacs/*` sub-deps) requires Node `^20.17 || >=22.9`. Every job running on Node 16/18 therefore flooded `npm ci` with `npm warn EBADENGINE`. Node 16 (EOL 2023-09) and Node 18 (EOL 2025-04) are both past end-of-life.

## Changes

- **All jobs now run on Node 20** — `security` and `commitlint` bumped from 18 → 20; `test` matrix reduced to `[20.x]` (was `[16.x, 18.x, 20.x]`). Eliminates EBADENGINE across every job.
- **`codecov/codecov-action@v3` → `@v5`** (clears its Node 20 action-runtime deprecation; renamed input `file` → `files`; moved the upload to the 20.x job).

## Verified

- EBADENGINE: **0** across all jobs (lint, test, security, commitlint).
- All checks green.

## Not actionable here (left as-is)

- `actions/github-script` Node 20 deprecation — emitted from *inside* `codecov-action@v5` (already latest); needs a Codecov upstream fix.
- Node-internal `DEP0040 punycode` / `DEP0169 url.parse` — from transitive dependencies, not our code.
- `engines` stays `>=14.0.0`; CI now only exercises Node 20, so tightening the supported range is a separate support-policy decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)